### PR TITLE
Potential Partial Solution for "Errors with dub test"

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,5 +13,27 @@
     "-ddoxFilterArgs": [
         "--ex", "mir.",
         "--unittest-examples"
-    ]
+    ],
+    "buildTypes": {
+		"unittest": {
+			"buildOptions": ["unittests", "debugMode", "debugInfo"],
+			"versions": ["mir_test"],
+            "preBuildCommands": ["cd test && python test_npy_fileio.py && cd .."]
+		},
+		"unittest-cov": {
+			"buildOptions": ["unittests", "coverage", "debugMode", "debugInfo"],
+			"versions": ["mir_test"],
+            "preBuildCommands": ["cd test && python test_npy_fileio.py && cd .."]
+		}
+	},
+	"configurations": [
+		{
+			"name": "library",
+			"targetType": "library"
+		},
+		{
+			"name": "sourceLibrary",
+			"targetType": "sourceLibrary"
+		}
+	],
 }


### PR DESCRIPTION
Addressing issue #15, I propose to add some configurations to the dub.json and then use preBuildCommands (I wasn't entirely sure if this is what should be used or preGenerateCommands) to run the python code necessary for the unittests. 

When I make these adjustments, dub test works again on Windows and doesn't require additional work, but it seems to do the preBuildCommands multiple times (hence the comment above on preGenerateCommands). 

I also believe there should be some way to detect that the commands fail, such as if python is not detected, and skip those tests. So that's why I'm referring to it as a partial solution.